### PR TITLE
minify html before translation

### DIFF
--- a/translatehtml/translatehtml.py
+++ b/translatehtml/translatehtml.py
@@ -62,7 +62,8 @@ def translate_html(underlying_translation, html):
     Returns:
         str: Translated HTML string
     """
-    soup = BeautifulSoup(html, "html.parser")
+    minhtml = ' '.join(html.split()) # minified version of html
+    soup = BeautifulSoup(minhtml, "html.parser")
     itag = itag_of_soup(soup)
     translated_tag = translate_tags(underlying_translation, itag)
     translated_soup = soup_of_itag(translated_tag)


### PR DESCRIPTION
Addresses issue #10 by sending a "minified" version of the html string to the translation engine. There may be subtle differences by HTML's definition of whitespace and python's but it works in my use cases. 