### PR TITLE
Use clear & extend instead of modifying contents

### DIFF
--- a/translatehtml/translatehtml.py
+++ b/translatehtml/translatehtml.py
@@ -48,7 +48,8 @@ def soup_of_itag(itag):
     if type(itag) == str:
         return bs4.element.NavigableString(itag)
     soup = itag.soup
-    soup.contents = [soup_of_itag(child) for child in itag.children]
+    soup.clear()
+    soup.extend([soup_of_itag(child) for child in itag.children])
     return soup
 
 


### PR DESCRIPTION
This fixes translation with beautifulsoup4>=4.12.1
Modifying contents list directly [is not supported](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#contents-and-children) by BeautifulSoup:

> If you want to modify a tag’s children, use the methods described in Modifying the tree. Don’t modify the the .contents list directly: that can lead to problems that are subtle and difficult to spot.

Closes https://github.com/argosopentech/translate-html/issues/14